### PR TITLE
Retrive tag list from Quay.io

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,91 +1,14 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/url"
 	"os"
-	"path"
 	"strings"
 )
 
 const Usage = `Usage:
   dockertags IMAGENAME
 `
-
-const QuayURLBase = "https://quay.io/api/v1/repository/"
-
-type QuayTag struct {
-	Revision      bool   `json:"revision"`
-	StartTs       int    `json:"start_ts"`
-	Name          string `json:"name"`
-	DockerImageID string `json:"docker_image_id"`
-}
-
-type QuayTagsResponse struct {
-	HasAdditional bool      `json:"has_additional"`
-	Page          int       `json:"page"`
-	Tags          []QuayTag `json:"tags"`
-}
-
-func constructURL(base, image string) (string, error) {
-	u, err := url.Parse(base)
-	if err != nil {
-		return "", err
-	}
-
-	u.Path = path.Join(u.Path, image, "tag")
-
-	return u.String(), nil
-}
-
-func httpGet(url string) (string, error) {
-	resp, err := http.Get(url)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("HTTP error!\nURL: %s\nstatus code: %d\nbody:\n%s\n", url, resp.StatusCode, string(b))
-	}
-
-	return string(b), nil
-}
-
-func retriveFromQuay(image string) ([]string, error) {
-	url, err := constructURL(QuayURLBase, image)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-
-	body, err := httpGet(url)
-	if err != nil {
-		return nil, err
-	}
-
-	var resp QuayTagsResponse
-
-	if err := json.Unmarshal([]byte(body), &resp); err != nil {
-		return nil, err
-	}
-
-	tags := []string{}
-
-	for _, tag := range resp.Tags {
-		tags = append(tags, tag.Name)
-	}
-
-	return tags, nil
-}
 
 func main() {
 	if len(os.Args) != 2 {

--- a/main.go
+++ b/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+)
+
+const Usage = `Usage:
+  dockertags IMAGENAME
+`
+
+const QuayURLBase = "https://quay.io/api/v1/repository/"
+
+func constructURL(base, image string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+
+	u.Path = path.Join(u.Path, image, "tag")
+
+	return u.String(), nil
+}
+
+func httpGet(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP error!\nURL: %s\nstatus code: %d\nbody:\n%s\n", url, resp.StatusCode, string(b))
+	}
+
+	return string(b), nil
+}
+
+func retriveFromQuay(image string) ([]string, error) {
+	url, err := constructURL(QuayURLBase, image)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	body, err := httpGet(url)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: parse JSON
+	fmt.Println(body)
+
+	return []string{}, nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, Usage)
+		os.Exit(1)
+	}
+
+	var (
+		repo  string
+		image string
+	)
+
+	ss := strings.Split(os.Args[1], "/")
+
+	if len(ss) > 2 {
+		repo = ss[0]
+		image = strings.Join(ss[1:], "/")
+	} else {
+		repo = "index.docker.io"
+		image = strings.Join(ss, "/")
+	}
+
+	var tags []string
+
+	switch repo {
+	case "index.docker.io":
+	case "quay.io":
+		t, err := retriveFromQuay(image)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		tags = t
+	default:
+
+	}
+
+	for _, tag := range tags {
+		fmt.Println(tag)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,8 @@ func main() {
 
 	switch repo {
 	case "index.docker.io":
+		fmt.Fprintln(os.Stderr, "Retrive from Docker Hub is NOT implemented yet...")
+		os.Exit(1)
 	case "quay.io":
 		t, err := retriveFromQuay(image)
 		if err != nil {
@@ -44,7 +46,8 @@ func main() {
 
 		tags = t
 	default:
-
+		fmt.Fprintf(os.Stderr, "Unsupported image repository: %s\n", repo)
+		os.Exit(1)
 	}
 
 	for _, tag := range tags {

--- a/quay.go
+++ b/quay.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"net/url"
+	"path"
+)
+
+const QuayURLBase = "https://quay.io/api/v1/repository/"
+
+type QuayTag struct {
+	Revision      bool   `json:"revision"`
+	StartTs       int    `json:"start_ts"`
+	Name          string `json:"name"`
+	DockerImageID string `json:"docker_image_id"`
+}
+
+type QuayTagsResponse struct {
+	HasAdditional bool      `json:"has_additional"`
+	Page          int       `json:"page"`
+	Tags          []QuayTag `json:"tags"`
+}
+
+func constructQuayURL(image string) (string, error) {
+	u, err := url.Parse(QuayURLBase)
+	if err != nil {
+		return "", err
+	}
+
+	u.Path = path.Join(u.Path, image, "tag")
+
+	return u.String(), nil
+}
+
+func retriveFromQuay(image string) ([]string, error) {
+	url, err := constructQuayURL(image)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := httpGet(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp QuayTagsResponse
+
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		return nil, err
+	}
+
+	tags := []string{}
+
+	for _, tag := range resp.Tags {
+		tags = append(tags, tag.Name)
+	}
+
+	return tags, nil
+}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+func httpGet(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP error!\nURL: %s\nstatus code: %d\nbody:\n%s\n", url, resp.StatusCode, string(b))
+	}
+
+	return string(b), nil
+}


### PR DESCRIPTION
migrate from [github.com/wantedly/kubedeploy/get.go](https://github.com/wantedly/kubedeploy/blob/a8f1ebcd180672e69ef5bf6b7bc82644c527d592/get.go#L26-L63)
## WHY

A function to retrive tag list in remote image repository should be isolated tool.
## WHAT

Implement initial command line tool and function to retrive tag list from Quay.io.
