### PR TITLE
Prepare Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+README.md
+LICENSE
+bin
+dockertags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:3.4
+
+ENV GOPATH /go
+
+RUN apk add --no-cache --update ca-certificates
+
+COPY . /go/src/github.com/wantedly/dockertags
+
+RUN apk add --no-cache --update --virtual=build-deps go git make mercurial \
+    && cd /go/src/github.com/wantedly/dockertags \
+    && make \
+    && cp bin/dockertags /dockertags \
+    && cd / \
+    && rm -rf /go \
+    && apk del build-deps
+
+ENTRYPOINT ["/dockertags"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # docekrtags - Retrive available Docker image tag list from image repository
 
+[![Docker Repository on Quay](https://quay.io/repository/wantedly/dockertags/status "Docker Repository on Quay")](https://quay.io/repository/wantedly/dockertags)
+
 ## License
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# docekrtags - Retrive available Docker image tag list from image repository
+# dockertags - Retrive available Docker image tag list from image repository
 
 [![Docker Repository on Quay](https://quay.io/repository/wantedly/dockertags/status "Docker Repository on Quay")](https://quay.io/repository/wantedly/dockertags)
 


### PR DESCRIPTION
## WHY

To run `dockertags` as Docker container, we have to prepare Docker image beforehand.
## WHAT

Add `Dockerfile` and prepare image repository [quay.io/wantedly/dockertags](https://quay.io/repository/wantedly/dockertags).

Build hook is already configured, so new Docker image will be built automatically by new master commit.
