### PR TITLE
Set QUAYIO_TOKEN to header

### DIFF
--- a/quay.go
+++ b/quay.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"net/url"
+	"os"
 	"path"
 )
 
@@ -38,7 +39,7 @@ func retriveFromQuay(image string) ([]string, error) {
 		return nil, err
 	}
 
-	body, err := httpGet(url)
+	body, err := httpGet(url, os.Getenv("QUAYIO_TOKEN"))
 	if err != nil {
 		return nil, err
 	}

--- a/quay.go
+++ b/quay.go
@@ -27,7 +27,7 @@ func constructQuayURL(image string) (string, error) {
 		return "", err
 	}
 
-	u.Path = path.Join(u.Path, image, "tag")
+	u.Path = path.Join(u.Path, image, "tag") + "/"
 
 	return u.String(), nil
 }

--- a/util.go
+++ b/util.go
@@ -4,10 +4,15 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 )
 
 func httpGet(url string) (string, error) {
-	resp, err := http.Get(url)
+
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+os.Getenv("QUAYIO_TOKEN"))
+	client := new(http.Client)
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/util.go
+++ b/util.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 )
 
-func httpGet(url string) (string, error) {
-
+func httpGet(url, apiToken string) (string, error) {
 	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Set("Authorization", "Bearer "+os.Getenv("QUAYIO_TOKEN"))
+	if apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+apiToken)
+	}
 	client := new(http.Client)
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
## WHY

`kubedeploy` cannnot get private registry information.
## WHAY

Set `quay.io token` to http Header
