### PR TITLE
Deploy binary packages to GitHub Releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ _testmain.go
 
 /dockertags
 /bin
+/dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: go
+go:
+  - '1.8'
+before_install:
+  - sudo add-apt-repository ppa:masterminds/glide -y
+  - sudo apt-get update -q
+  - sudo apt-get install glide -y
+  - mkdir -p $GOPATH/bin
+install:
+  - make deps
+script:
+  - make test
+before_deploy:
+  - make cross-build
+  - make dist
+deploy:
+  - provider: releases
+    skip_cleanup: true
+    api_key: $GITHUB_TOKEN
+    file_glob: true
+    file: 'dist/*.{tar.gz,zip}'
+    on:
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: go
 go:
   - '1.8'
+env:
+  global:
+  - secure: YtIXb4e4cHUWP5awg1q/x7eBsRULWM4CBZUvYs7U/pMre52oaCkT0IRCZ/sWfUiU8x6ax9NytrcF5JudH9uhysNDqcJcPyBmifloY0DEC9V2tGnnm/VeOS8nKVYbgJcFqsu4x9gdTfUC6HZ/hkTwIQih57ig5STeFX21eLAWSyUkyxq2QpM56Yhtxuc6IZ/K0uOFbLn0A2cV46Cwlln6lwDmTt23MWb8ZMwggd+EUptoj6kvQCJxuoP09k7xLIg6FB/lgKHsGqnIhEvt/A87vSCttYbBRN3CT8qgbVYKsL37nML3QH2akMkHacHSB7tEZCl+sTuK7b6T3fr3OrhuHZFjk2Q2JvFKMuVvv7m1bOulurA++WCOrxKq9CLqKaL51k2XzEr0BrqO2bWWMpEEq4JuTcRM5uCi2IORzyCPhO4li527GFHyQs1bDrdPcSm9xmlw9/QIqaS0g+3v7ve2qEVQpNLHlVkidb9D2nFztVFOnUfHUKwYvK/CT/bxuwZd2t65Jex1faVmyo3SCztHGs9UUzS72TrzT7GRj7azXvygRC9Fx1kuDCRHDVERw8dHGircYuu2XpqSL+iuQwY5pIP8Ql1tD9rJojN/oYm51u5rCRgYA/NyEuPAlloEj1M50Iut6blNeYY3J1sVCwVyTXnjLJupJaFSMs1wS22GHks=
 before_install:
   - sudo add-apt-repository ppa:masterminds/glide -y
   - sudo apt-get update -q

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 NAME := dockertags
+VERSION := v0.1.0
+REVISION := $(shell git rev-parse --short HEAD)
+
 SRCS := $(shell find . -name '*.go' -type f)
 LDFLAGS := -ldflags="-s -w"
+
+DIST_DIRS := find * -type d -exec
 
 .DEFAULT_GOAL := bin/$(NAME)
 
@@ -10,3 +15,22 @@ bin/$(NAME): $(SRCS)
 .PHONY: clean
 clean:
 	rm -rf bin/*
+	rm -rf dist/*
+	rm -rf vendor/*
+
+.PHONY: cross-build
+cross-build:
+	for os in darwin linux windows; do \
+		for arch in amd64 386; do \
+			GOOS=$$os GOARCH=$$arch CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo $(LDFLAGS) -o dist/$$os-$$arch/$(NAME); \
+		done; \
+	done
+
+.PHONY: dist
+dist:
+	cd dist && \
+	$(DIST_DIRS) cp ../LICENSE {} \; && \
+	$(DIST_DIRS) cp ../README.md {} \; && \
+	$(DIST_DIRS) tar -zcf $(NAME)-$(VERSION)-{}.tar.gz {} \; && \
+	$(DIST_DIRS) zip -r $(NAME)-$(VERSION)-{}.zip {} \; && \
+	cd ..

--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,8 @@ glide:
 ifeq ($(shell command -v glide 2> /dev/null),)
 	curl https://glide.sh/get | sh
 endif
+
+.PHONY: release
+release:
+	git tag $(VERSION)
+	git push origin $(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,7 @@ endif
 release:
 	git tag $(VERSION)
 	git push origin $(VERSION)
+
+.PHONY: test
+test:
+	go test -cover -v `glide novendor`

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ cross-build:
 		done; \
 	done
 
+.PHONY: deps
+deps: glide
+	glide install
+
 .PHONY: dist
 dist:
 	cd dist && \
@@ -34,3 +38,9 @@ dist:
 	$(DIST_DIRS) tar -zcf $(NAME)-$(VERSION)-{}.tar.gz {} \; && \
 	$(DIST_DIRS) zip -r $(NAME)-$(VERSION)-{}.zip {} \; && \
 	cd ..
+
+.PHONY: glide
+glide:
+ifeq ($(shell command -v glide 2> /dev/null),)
+	curl https://glide.sh/get | sh
+endif

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,4 @@
+hash: d16acbdeac49ba0272ca16c80345bce6d717228b62b3c040bf2e9dd7b2f2ec62
+updated: 2017-04-13T11:56:35.046079443+09:00
+imports: []
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,2 @@
+package: github.com/wantedly/dockertags
+import: []


### PR DESCRIPTION
## WHY

To download stable binaries from anywhere.

## WHAT

Deploy binary packages (tarball, zipball) from Travis CI to GitHub Releases with git tag.