### PR TITLE
Enable retrieving official image of DockerHub

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,10 @@ func main() {
 	if len(ss) > 2 {
 		repo = ss[0]
 		image = strings.Join(ss[1:], "/")
+	} else if len(ss) == 1 {
+		// Official image of DockerHub
+		repo = "hub.docker.com"
+		image = strings.Join(append([]string{"library"}, ss...), "/")
 	} else {
 		repo = "hub.docker.com"
 		image = strings.Join(ss, "/")


### PR DESCRIPTION
## Why

When retrieving the official image of DockerHub it is necessary to specify `library/`.

e.g. `$ dockertags library/docker`

But what you need `library/` is not intuitive.

If `library/` is not specified, the following error will occur.

<details>
<summary>error detail</summary>

```
$ dockertags docker
HTTP error!
URL: https://registry.hub.docker.com/v2/docker/tags/list
status code: 404
body:
<!doctype html>
<html class="no-js" lang="">
    <head>
        <meta charset="utf-8">
        <meta http-equiv="X-UA-Compatible" content="IE=edge"><script type="text/javascript">window.NREUM||(NREUM={}),__nr_require=function(e,t,n){function r(n){if(!t[n]){var o=t[n]={exports:{}};e[n][0].call(o.exports,function(t){var o=e[n][1][t];return r(o||t)},o,o.exports)}return t[n].exports}if("function"==typeof __nr_require)return __nr_require;for(var o=0;o<n.length;o++)r(n[o]);return r}({1:[function(e,t,n){function r(){}function o(e,t,n){return function(){return i(e,[f.now()].concat(u(arguments)),t?null:this,n),t?void 0:this}}var i=e("handle"),a=e(2),u=e(3),c=e("ee").get("tracer"),f=e("loader"),s=NREUM;"undefined"==typeof window.newrelic&&(newrelic=s);var p=["setPageViewName","setCustomAttribute","setErrorHandler","finished","addToTrace","inlineHit","addRelease"],d="api-",l=d+"ixn-";a(p,function(e,t){s[t]=o(d+t,!0,"api")}),s.addPageAction=o(d+"addPageAction",!0),s.setCurrentRouteName=o(d+"routeName",!0),t.exports=newrelic,s.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(e,t){var n={},r=this,o="function"==typeof t;return i(l+"tracer",[f.now(),e,n],r),function(){if(c.emit((o?"":"no-")+"fn-start",[f.now(),r,o],n),o)try{return t.apply(this,arguments)}catch(e){throw c.emit("fn-err",[arguments,this,e],n),e}finally{c.emit("fn-end",[f.now()],n)}}}};a("setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","),function(e,t){m[t]=o(l+t)}),newrelic.noticeError=function(e){"string"==typeof e&&(e=new Error(e)),i("err",[e,f.now()])}},{}],2:[function(e,t,n){function r(e,t){var n=[],r="",i=0;for(r in e)o.call(e,r)&&(n[i]=t(r,e[r]),i+=1);return n}var o=Object.prototype.hasOwnProperty;t.exports=r},{}],3:[function(e,t,n){function r(e,t,n){t||(t=0),"undefined"==typeof n&&(n=e?e.length:0);for(var r=-1,o=n-t||0,i=Array(o<0?0:o);++r<o;)i[r]=e[t+r];return i}t.exports=r},{}],4:[function(e,t,n){t.exports={exists:"undefined"!=typeof window.performance&&window.performance.timing&&"undefined"!=typeof window.performance.timing.navigationStart}},{}],ee:[function(e,t,n){function r(){}function o(e){function t(e){return e&&e instanceof r?e:e?c(e,u,i):i()}function n(n,r,o,i){if(!d.aborted||i){e&&e(n,r,o);for(var a=t(o),u=m(n),c=u.length,f=0;f<c;f++)u[f].apply(a,r);var p=s[y[n]];return p&&p.push([b,n,r,a]),a}}function l(e,t){v[e]=m(e).concat(t)}function m(e){return v[e]||[]}function w(e){return p[e]=p[e]||o(n)}function g(e,t){f(e,function(e,n){t=t||"feature",y[n]=t,t in s||(s[t]=[])})}var v={},y={},b={on:l,emit:n,get:w,listeners:m,context:t,buffer:g,abort:a,aborted:!1};return b}function i(){return new r}function a(){(s.api||s.feature)&&(d.aborted=!0,s=d.backlog={})}var u="nr@context",c=e("gos"),f=e(2),s={},p={},d=t.exports=o();d.backlog=s},{}],gos:[function(e,t,n){function r(e,t,n){if(o.call(e,t))return e[t];var r=n();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,t,{value:r,writable:!0,enumerable:!1}),r}catch(i){}return e[t]=r,r}var o=Object.prototype.hasOwnProperty;t.exports=r},{}],handle:[function(e,t,n){function r(e,t,n,r){o.buffer([e],r),o.emit(e,t,n)}var o=e("ee").get("handle");t.exports=r,r.ee=o},{}],id:[function(e,t,n){function r(e){var t=typeof e;return!e||"object"!==t&&"function"!==t?-1:e===window?0:a(e,i,function(){return o++})}var o=1,i="nr@id",a=e("gos");t.exports=r},{}],loader:[function(e,t,n){function r(){if(!x++){var e=h.info=NREUM.info,t=d.getElementsByTagName("script")[0];if(setTimeout(s.abort,3e4),!(e&&e.licenseKey&&e.applicationID&&t))return s.abort();f(y,function(t,n){e[t]||(e[t]=n)}),c("mark",["onload",a()+h.offset],null,"api");var n=d.createElement("script");n.src="https://"+e.agent,t.parentNode.insertBefore(n,t)}}function o(){"complete"===d.readyState&&i()}function i(){c("mark",["domContent",a()+h.offset],null,"api")}function a(){return E.exists&&performance.now?Math.round(performance.now()):(u=Math.max((new Date).getTime(),u))-h.offset}var u=(new Date).getTime(),c=e("handle"),f=e(2),s=e("ee"),p=window,d=p.document,l="addEventListener",m="attachEvent",w=p.XMLHttpRequest,g=w&&w.prototype;NREUM.o={ST:setTimeout,SI:p.setImmediate,CT:clearTimeout,XHR:w,REQ:p.Request,EV:p.Event,PR:p.Promise,MO:p.MutationObserver};var v=""+location,y={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-1071.min.js"},b=w&&g&&g[l]&&!/CriOS/.test(navigator.userAgent),h=t.exports={offset:u,now:a,origin:v,features:{},xhrWrappable:b};e(1),d[l]?(d[l]("DOMContentLoaded",i,!1),p[l]("load",r,!1)):(d[m]("onreadystatechange",o),p[m]("onload",r)),c("mark",["firstbyte",u],null,"api");var x=0,E=e(4)},{}]},{},["loader"]);</script><script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","queueTime":1,"licenseKey":"971b6146e9","agent":"","transactionName":"Yl1QMUFZV0JVV0IIWVsXdBBdW01YW1oZAllYVV0LHU5QVENHDAJDRkxdCGxIWFZRa1gOQmpeXRBdXA==","applicationID":"6929817","errorBeacon":"bam.nr-data.net","applicationTime":5}</script>
        <title></title>
        <meta name="description" content="">
        <meta name="viewport" content="width=device-width, initial-scale=1">

        <style type="text/css">
        body {
            background: #02425a;
            text-align:center;
            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
        }
        h1 {
            color:white;
            text-shadow: 1px 1px black;
        }
        .svg{
            width:50%;
            margin: auto;
        }
        a {
            color:#05b3f4;
        }
        p {
            color: #047aa7;
        }
        @media screen and (max-width: 758px) {
            .svg {
                width: 100%;
            }
        }
        </style>

    </head>
    <body>
        <!--[if lt IE 8]>
            <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
        <![endif]-->
<div class="svg">
        <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
     viewBox="0 0 792 268.4" enable-background="new 0 0 792 268.4" xml:space="preserve">
<path id="outline_5_" display="none" fill-rule="evenodd" clip-rule="evenodd" fill="#394D54" d="M274.1-112.5h42.7v43.6h21.6
    c10,0,20.2-1.8,29.7-5c4.6-1.6,9.8-3.8,14.4-6.5c-6-7.9-9.1-17.8-10-27.6c-1.2-13.3,1.5-30.7,10.5-41.1l4.5-5.2l5.3,4.3
    c13.5,10.8,24.8,25.9,26.8,43.2c16.2-4.8,35.2-3.6,49.5,4.6l5.9,3.4l-3.1,6c-12.1,23.6-37.4,30.9-62.1,29.6
    c-37,92.1-117.4,135.7-215,135.7c-50.4,0-96.7-18.8-123-63.6l-0.4-0.7l-3.8-7.8c-8.9-19.7-11.9-41.3-9.9-62.8l0.6-6.5h36.5v-43.6
    h42.7v-42.7h85.4v-42.7h51.2V-112.5z"/>
<g display="none">
    <path display="inline" fill="#394D54" d="M110.2,24.6c5.5,0,10.7-0.1,15.6-0.4c0.4,0,0.8-0.1,1.3-0.1c0,0,0,0,0,0
        c12.6-0.8,23.4-2.5,32.5-5c0,0,0,0,0,0c1.7-0.5,3.2-1,4.8-1.5c1.7-0.6,2.6-2.5,2-4.2c-0.6-1.7-2.5-2.6-4.2-2
        c-11.5,4-26.7,6.2-45.4,6.6c0,0,0,0,0,0c-9.5,0.2-19.9,0-31.1-0.8h0c-0.6,0-1.1-0.1-1.7-0.1c-1.8-0.1-3.4,1.2-3.5,3.1
        c-0.1,1.8,1.2,3.4,3.1,3.5c2.3,0.2,4.6,0.3,6.8,0.4c0.4,0,0.7,0,1,0l0,0C97.9,24.4,104.2,24.6,110.2,24.6z"/>
</g>
<path fill-rule="evenodd" clip-rule="evenodd" fill="#E7E7E7" d="M634.3,161.9c8.7-7.5,17.4-15,26.1-22.5c3-2.6,6.2-5.2,9.2-7.9
    c-2.4-3-6.3-5.1-9.7-6.4c-6.8-2.6-13.5-1.7-19.7,1.9c-8.1,4.7-11.6,12.2-11.3,21.5c0.1,3.7,1.1,7.2,3.1,10.3
    C632.7,159.9,633.5,160.9,634.3,161.9 M644.4,169c4.3,1.5,9.1,1.3,13.5,0.5c2.2-1,8-3.5,10.1-3.1l0.3,0.1l0.3,0.1
    c1.3,0.6,2.5,1.5,3.2,2.8c1.5,3.1,0.8,6.2-2.2,7.9l-1,0.6c-11.1,6.4-23,5.5-34.1-0.5c-5.3-2.9-9.4-7.1-12.4-12.3l-0.7-1.2
    c-7.2-12.4-6.2-25.4,1.9-37.2c2.8-4.1,6.4-7.2,10.7-9.7l1.6-0.9c10.5-6.1,21.7-5.6,32.5-0.3c5.8,2.9,10.5,7.1,13.7,12.7l0.6,1
    c2.3,4.1-0.7,7.6-3.8,10.1c-3.6,2.8-7.3,6.2-10.8,9.2C660,155.5,652.2,162.2,644.4,169z M727.9,112.6h1.2c3.5,0,5.9,2.4,5.9,5.9
    c0,4.9-4.6,6.1-8.7,6.1c-5.3,0-10.3,3.2-14,6.8c-4.5,4.5-6.5,10.2-6.5,16.5v28.4c0,3.3-2,5.9-5.4,5.9h-0.9c-3.4,0-5.4-2.6-5.4-5.9
    v-30.1c0-11.5,5.6-21,15-27.6C714.7,114.7,721.1,112.6,727.9,112.6z M581.5,132.8c4.6-4.6,9.1-9.1,13.8-13.6
    c1.3-1.3,6.2-6.6,8.1-6.6h2.1l0.2,0.1c2.7,0.6,4.7,2.3,4.7,5.1v1.2c0,2-2.3,4.2-3.6,5.6c-2.7,2.9-5.5,5.6-8.3,8.4l-14.2,14.4
    c6.1,6.1,12.2,12.3,18.3,18.4c1.7,1.7,3.4,3.4,5,5.1c0.6,0.6,1.4,1.4,1.9,2.2c0.5,0.8,0.8,1.7,0.8,2.7v1.2l-0.1,0.3
    c-0.7,2.7-2.4,4.8-5.3,4.8h-0.9c-1.9,0-4.1-2.2-5.5-3.5c-2.7-2.6-5.4-5.3-8.1-7.9l-9-8.9v14.2c0,3.3-2,5.9-5.4,5.9h-0.9
    c-3.4,0-5.4-2.6-5.4-5.9V96.3c0-3.3,2-5.9,5.4-5.9h0.9c3.4,0,5.4,2.6,5.4,5.9V132.8z M543.4,124.8c-1.8-0.8-5.1-1.1-7-1.2
    c-9.8-0.4-16.9,5.2-21.1,13.8c-1.4,3-2.1,6.1-2.1,9.5c0,10.1,5.3,17.1,14.3,21.4c3.3,1.6,7.5,1.9,11.1,1.9c3.2,0,7.6-1.9,10.4-3.3
    l0.5-0.2h2.2l0.2,0c2.7,0.6,4.7,2.2,4.7,5.1v1.2c0,7.1-13.1,8.8-18.1,9.1c-17.6,1.2-30.8-8.4-35.8-25.2c-0.9-2.9-1.3-5.8-1.3-8.8
    v-2.3c0-12.7,6.3-22.8,17.2-29.3c5.1-3,10.7-4.5,16.6-4.5h2.3c6.3,0,12,1.8,17.2,5.3l0.4,0.3l0.3,0.4c0.6,0.9,1,2,1,3.1v1.2
    c0,3-2.2,4.6-5,5.1l-0.2,0h-0.7C549,127.4,545,125.6,543.4,124.8z M436.3,147.2c0,8.9,4.4,15.5,11.9,20.1c3.5,2.2,7.4,3.2,11.6,3.2
    c8.8,0,15.3-4.5,19.9-11.9c2.2-3.5,3.1-7.4,3.1-11.6c0-8.3-4-14.6-10.8-19.2c-3.7-2.5-7.9-3.8-12.4-3.8c-9.8,0-16.9,5-21.2,13.8
    C436.9,140.7,436.3,143.9,436.3,147.2z M458.4,112.1h1.6c13.6,0,24,6.6,30.5,18.5c2.6,4.8,4,9.9,4,15.4v2.3
    c0,12.7-6.3,22.9-17.3,29.3c-5.1,3-10.7,4.5-16.6,4.5h-2.3c-12.7,0-22.9-6.3-29.3-17.3c-3-5.1-4.5-10.7-4.5-16.6V146
    c0-12.7,6.3-22.8,17.2-29.3C446.9,113.6,452.5,112.1,458.4,112.1z M359.4,147.2c0,9.2,4.5,16.1,12.5,20.5c3.3,1.8,6.8,2.7,10.5,2.7
    c9,0,15.7-4.3,20.3-11.9c2.1-3.6,3.2-7.5,3.2-11.6c0-8-3.8-14.2-10.2-18.8c-3.9-2.8-8.3-4.2-13.1-4.2c-9.8,0-16.9,5-21.2,13.8
    C360,140.7,359.4,143.9,359.4,147.2z M405.9,120.9V96.1c0-3.3,2-5.9,5.4-5.9h0.9c3.4,0,5.4,2.6,5.4,5.9v52.2
    c0,12.7-6.3,22.9-17.3,29.3c-5.1,3-10.7,4.5-16.6,4.5h-2.3c-12.7,0-22.9-6.3-29.3-17.3c-3-5.1-4.5-10.7-4.5-16.6V146
    c0-12.7,6.3-22.9,17.2-29.3c5.1-3,10.7-4.5,16.6-4.5h2.3C392.4,112.1,399.7,115.5,405.9,120.9z"/>
<g>
    <g id="body_colors_6_">
        <path fill="#00AADA" d="M300.1,110.9c1.7-13.3-8.2-23.7-14.4-28.7c-7.1,8.2-8.2,29.7,2.9,38.8c-6.2,5.5-19.3,10.5-32.7,10.5H92.6
            c-1.3,14,1.2,26.9,6.8,37.9l1.9,3.4c1.2,2,2.5,3.9,3.8,5.8l0,0c6.7,0.4,12.9,0.6,18.6,0.5h0c11.1-0.2,20.2-1.6,27.1-3.9
            c1-0.4,2.1,0.2,2.5,1.2c0.4,1-0.2,2.1-1.2,2.5c-0.9,0.3-1.9,0.6-2.9,0.9c0,0,0,0,0,0c-5.4,1.5-11.2,2.6-18.7,3.1
            c0.4,0-0.5,0.1-0.5,0.1c-0.3,0-0.6,0.1-0.8,0.1c-3,0.2-6.1,0.2-9.4,0.2c-3.6,0-7.1-0.1-11-0.3l-0.1,0.1
            c13.6,15.3,34.9,24.5,61.5,24.5c56.4,0,104.3-25,125.5-81.2c15,1.5,29.5-2.3,36.1-15.1C321.3,105,307.9,107,300.1,110.9z"/>
        <path fill="#24B8EB" d="M300.1,110.9c1.7-13.3-8.2-23.7-14.4-28.7c-7.1,8.2-8.2,29.7,2.9,38.8c-6.2,5.5-19.3,10.5-32.7,10.5H102.3
            c-0.7,21.4,7.3,37.7,21.4,47.6h0c11.1-0.2,20.2-1.6,27.1-3.9c1-0.4,2.1,0.2,2.5,1.2c0.4,1-0.2,2.1-1.2,2.5
            c-0.9,0.3-1.9,0.6-2.9,0.9c0,0,0,0,0,0c-5.4,1.5-11.7,2.7-19.2,3.2c0,0-0.2-0.2-0.2-0.2c19.2,9.9,47.1,9.8,79-2.4
            c35.8-13.8,69.1-40,92.4-69.9C300.8,110.5,300.4,110.7,300.1,110.9z"/>
        <path fill="#008BB8" d="M92.9,148.5c1,7.5,3.2,14.5,6.5,20.9l1.9,3.4c1.2,2,2.5,3.9,3.8,5.8c6.7,0.4,12.9,0.6,18.6,0.5
            c11.1-0.2,20.2-1.6,27.1-3.9c1-0.4,2.1,0.2,2.5,1.2c0.4,1-0.2,2.1-1.2,2.5c-0.9,0.3-1.9,0.6-2.9,0.9c0,0,0,0,0,0
            c-5.4,1.5-11.7,2.7-19.2,3.1c-0.3,0-0.7,0-1,0c-3,0.2-6.1,0.3-9.4,0.3c-3.6,0-7.2-0.1-11.1-0.3c13.6,15.3,35,24.5,61.7,24.5
            c48.3,0,90.3-18.3,114.7-58.9H92.9z"/>
        <path fill="#039BC6" d="M103.8,148.5c2.9,13.2,9.8,23.5,19.9,30.5c11.1-0.2,20.2-1.6,27.1-3.9c1-0.4,2.1,0.2,2.5,1.2
            c0.4,1-0.2,2.1-1.2,2.5c-0.9,0.3-1.9,0.6-2.9,0.9c0,0,0,0,0,0c-5.4,1.5-11.8,2.7-19.3,3.1c19.2,9.9,47,9.7,78.9-2.6
            c19.3-7.4,37.9-18.5,54.6-31.8H103.8z"/>
    </g>
    <g id="Containers_6_">
        <path fill-rule="evenodd" clip-rule="evenodd" fill="#00ACD3" d="M133.3,107.3h1.7v18.4h-1.7V107.3z M129.9,107.3h1.8v18.4h-1.8
            V107.3z M126.6,107.3h1.8v18.4h-1.8V107.3z M123.3,107.3h1.8v18.4h-1.8V107.3z M119.9,107.3h1.8v18.4h-1.8V107.3z M116.6,107.3
            h1.7v18.4h-1.7V107.3z M114.8,105.5h22.1v22.1h-22.1V105.5z"/>
        <path fill-rule="evenodd" clip-rule="evenodd" fill="#00ACD3" d="M158.8,81.8h1.7v18.4h-1.7V81.8z M155.4,81.8h1.8v18.4h-1.8V81.8
            z M152.1,81.8h1.8v18.4h-1.8V81.8z M148.7,81.8h1.8v18.4h-1.8V81.8z M145.4,81.8h1.8v18.4h-1.8V81.8z M142.1,81.8h1.7v18.4h-1.7
            V81.8z M140.3,80h22.1v22.1h-22.1V80z"/>
        <path fill-rule="evenodd" clip-rule="evenodd" fill="#20C2EF" d="M158.8,107.3h1.7v18.4h-1.7V107.3z M155.4,107.3h1.8v18.4h-1.8
            V107.3z M152.1,107.3h1.8v18.4h-1.8V107.3z M148.7,107.3h1.8v18.4h-1.8V107.3z M145.4,107.3h1.8v18.4h-1.8V107.3z M142.1,107.3
            h1.7v18.4h-1.7V107.3z M140.3,105.5h22.1v22.1h-22.1V105.5z"/>
        <path fill-rule="evenodd" clip-rule="evenodd" fill="#00ACD3" d="M184.2,107.3h1.7v18.4h-1.7V107.3z M180.9,107.3h1.8v18.4h-1.8
            V107.3z M177.6,107.3h1.8v18.4h-1.8V107.3z M174.2,107.3h1.8v18.4h-1.8V107.3z M170.9,107.3h1.8v18.4h-1.8V107.3z M167.6,107.3
            h1.7v18.4h-1.7V107.3z M165.7,105.5h22.1v22.1h-22.1V105.5z"/>
        <path fill-rule="evenodd" clip-rule="evenodd" fill="#20C2EF" d="M184.2,81.8h1.7v18.4h-1.7V81.8z M180.9,81.8h1.8v18.4h-1.8V81.8
            z M177.6,81.8h1.8v18.4h-1.8V81.8z M174.2,81.8h1.8v18.4h-1.8V81.8z M170.9,81.8h1.8v18.4h-1.8V81.8z M167.6,81.8h1.7v18.4h-1.7
            V81.8z M165.7,80h22.1v22.1h-22.1V80z"/>
        <path fill-rule="evenodd" clip-rule="evenodd" fill="#20C2EF" d="M209.7,107.3h1.7v18.4h-1.7V107.3z M206.4,107.3h1.8v18.4h-1.8
            V107.3z M203,107.3h1.8v18.4H203V107.3z M199.7,107.3h1.8v18.4h-1.8V107.3z M196.3,107.3h1.8v18.4h-1.8V107.3z M193.1,107.3h1.7
            v18.4h-1.7V107.3z M191.2,105.5h22.1v22.1h-22.1V105.5z"/>
        <path fill-rule="evenodd" clip-rule="evenodd" fill="#00ACD3" d="M209.7,81.8h1.7v18.4h-1.7V81.8z M206.4,81.8h1.8v18.4h-1.8V81.8
            z M203,81.8h1.8v18.4H203V81.8z M199.7,81.8h1.8v18.4h-1.8V81.8z M196.3,81.8h1.8v18.4h-1.8V81.8z M193.1,81.8h1.7v18.4h-1.7V81.8
            z M191.2,80h22.1v22.1h-22.1V80z"/>
        <path fill-rule="evenodd" clip-rule="evenodd" fill="#20C2EF" d="M209.7,56.4h1.7v18.4h-1.7V56.4z M206.4,56.4h1.8v18.4h-1.8V56.4
            z M203,56.4h1.8v18.4H203V56.4z M199.7,56.4h1.8v18.4h-1.8V56.4z M196.3,56.4h1.8v18.4h-1.8V56.4z M193.1,56.4h1.7v18.4h-1.7V56.4
            z M191.2,54.5h22.1v22.1h-22.1V54.5z"/>
        <path fill-rule="evenodd" clip-rule="evenodd" fill="#00ACD3" d="M235.2,107.3h1.7v18.4h-1.7V107.3z M231.9,107.3h1.8v18.4h-1.8
            V107.3z M228.5,107.3h1.8v18.4h-1.8V107.3z M225.2,107.3h1.8v18.4h-1.8V107.3z M221.8,107.3h1.8v18.4h-1.8V107.3z M218.5,107.3
            h1.7v18.4h-1.7V107.3z M216.7,105.5h22.1v22.1h-22.1V105.5z"/>
    </g>
    <path fill-rule="evenodd" clip-rule="evenodd" fill="#D4EDF1" d="M161,163.4c3.4,0,6.1,2.7,6.1,6.1c0,3.4-2.7,6.1-6.1,6.1
        s-6.1-2.7-6.1-6.1C154.9,166.1,157.6,163.4,161,163.4"/>
    <path fill-rule="evenodd" clip-rule="evenodd" fill="#394D54" d="M161,165.1c0.6,0,1.1,0.1,1.6,0.3c-0.5,0.3-0.9,0.9-0.9,1.5
        c0,1,0.8,1.8,1.8,1.8c0.7,0,1.3-0.4,1.6-0.9c0.2,0.5,0.3,1.1,0.3,1.7c0,2.4-2,4.4-4.4,4.4c-2.4,0-4.4-2-4.4-4.4
        C156.6,167,158.6,165.1,161,165.1"/>
    <path fill-rule="evenodd" clip-rule="evenodd" fill="#394D54" d="M53.2,150.7h133.4h16.5h133.4c-6.2-1.6-19.5-3.7-17.3-11.8
        c-11.2,13-38.3,9.1-45.1,2.7c-7.6,11-51.9,6.8-55-1.8c-9.5,11.2-39.1,11.2-48.6,0c-3.1,8.6-47.4,12.8-55,1.8
        c-6.8,6.4-33.9,10.3-45.1-2.7C72.7,147.1,59.4,149.2,53.2,150.7"/>
    <path fill="#BFDBE0" d="M177.2,207.3c-15.1-7.2-23.4-16.9-28-27.5c-5.6,1.6-12.3,2.6-20.2,3.1c-2.9,0.2-6.1,0.3-9.3,0.3
        c-3.8,0-7.7-0.1-11.9-0.3c13.8,13.8,30.9,24.5,62.4,24.7C172.6,207.4,174.9,207.3,177.2,207.3z"/>
    <path fill="#D4EDF1" d="M154.8,189.5c-2.1-2.8-4.1-6.4-5.6-9.8c-5.6,1.6-12.3,2.6-20.2,3.1C134.4,185.7,142.1,188.4,154.8,189.5z"
        />
</g>
</svg>
</div>
        <h1>Page Not Found!</h1>
    </body>
</html>
```

</details>

## How

In the case of the official image of DockerHub, we automatically prepend `library/`.

e.g.

```
$ dockertags docker | head -n5
windowsservercore
test
test-windowsservercore
test-git
test-dind
```