### PR TITLE
Bump the version to v0.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME := dockertags
-VERSION := v0.1.0
+VERSION := v0.2.0
 REVISION := $(shell git rev-parse --short HEAD)
 
 SRCS := $(shell find . -name '*.go' -type f)


### PR DESCRIPTION
## WHY

To release.
#8 Enable retrieving official image of DockerHub

## WHAT

Bump the version to v0.2.0