### PR TITLE
Use the same image parser as docker cli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module dockertags
 
 go 1.14
+
+require (
+	github.com/docker/distribution v2.7.1+incompatible
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=

--- a/main.go
+++ b/main.go
@@ -3,7 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
+
+	"github.com/docker/distribution/reference"
 )
 
 const Usage = `Usage:
@@ -16,29 +17,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	var (
-		repo  string
-		image string
-	)
-
-	ss := strings.Split(os.Args[1], "/")
-
-	if len(ss) > 2 {
-		repo = ss[0]
-		image = strings.Join(ss[1:], "/")
-	} else if len(ss) == 1 {
-		// Official image of DockerHub
-		repo = "hub.docker.com"
-		image = strings.Join(append([]string{"library"}, ss...), "/")
-	} else {
-		repo = "hub.docker.com"
-		image = strings.Join(ss, "/")
+	ref, err := reference.ParseNormalizedNamed(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
+	repo, image := reference.SplitHostname(ref)
 
 	var tags []string
 
 	switch repo {
-	case "hub.docker.com":
+	case "docker.io", "hub.docker.com":
 		t, err := retrieveFromDockerHub(image)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
## Why

To support ECR image name.
https://github.com/wantedly/dockertags/pull/15#discussion_r447331475

The current logic cannot parse `[account id].dkr.ecr.[region name].amazonaws.com/[repository name]`.

## What

I changed the image name parser to the same as docker cli.
https://github.com/moby/moby/blob/a70842f9c84f92741877301f33651353eddb44bb/client/image_pull.go#L23