### PR TITLE
add param active tags only

### DIFF
--- a/quay.go
+++ b/quay.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/url"
 	"os"
-	"path"
 )
 
 const QuayURLBase = "https://quay.io/api/v1/repository/"
@@ -23,14 +22,19 @@ type QuayTagsResponse struct {
 }
 
 func constructQuayURL(image string) (string, error) {
-	u, err := url.Parse(QuayURLBase)
+	base, err := url.Parse(QuayURLBase)
+
 	if err != nil {
 		return "", err
 	}
 
-	u.Path = path.Join(u.Path, image, "tag") + "/"
+	endpoint, err := url.Parse(image + `/tag/?onlyActiveTags=true`)
 
-	return u.String(), nil
+	if err != nil {
+		return "", err
+	}
+
+	return base.ResolveReference(endpoint).String(), nil
 }
 
 func retriveFromQuay(image string) ([]string, error) {


### PR DESCRIPTION
## Why
tag results from quay.io contains inactive tags , for example : dockertags quay.io/cilium/cilium returns several similar tags
https://github.com/wantedly/dockertags/issues/21


## What
adding the var onlyactivetags=true gives a better result